### PR TITLE
[ACCEDOONECA-3623] Added preset header font support for MDHeader

### DIFF
--- a/MarkdownKit/Sources/Common/Elements/Header/MarkdownHeader.swift
+++ b/MarkdownKit/Sources/Common/Elements/Header/MarkdownHeader.swift
@@ -33,12 +33,15 @@ open class MarkdownHeader: MarkdownLevelElement {
       attributedString.deleteCharacters(in: range)
   }
 
-    open func attributesForLevel(_ level: Int) -> [NSAttributedString.Key: AnyObject] {
+  // Modified by Xiaochen Guo (xiaochen.guo@accedo.tv)
+  // The `bold()` function might return nil as some libs have different naming convention
+  // Now allow preset header font
+  open func attributesForLevel(_ level: Int) -> [NSAttributedString.Key: AnyObject] {
     var attributes = self.attributes
     if let font = font {
         let headerFontSize: CGFloat = font.pointSize + 4 + (-1 * CGFloat(level) * CGFloat(fontIncrease))
-      
-      attributes[NSAttributedString.Key.font] = font.withSize(headerFontSize).bold()
+        let targetFont = font.withSize((headerFontSize > font.pointSize) ? headerFontSize : font.pointSize)
+        attributes[NSAttributedString.Key.font] = targetFont.bold() ?? targetFont
     }
     return attributes
   }

--- a/MarkdownKit/Sources/Common/Elements/Header/MarkdownHeader.swift
+++ b/MarkdownKit/Sources/Common/Elements/Header/MarkdownHeader.swift
@@ -39,8 +39,7 @@ open class MarkdownHeader: MarkdownLevelElement {
   open func attributesForLevel(_ level: Int) -> [NSAttributedString.Key: AnyObject] {
     var attributes = self.attributes
     if let font = font {
-        let headerFontSize: CGFloat = font.pointSize + 4 + (-1 * CGFloat(level) * CGFloat(fontIncrease))
-        let targetFont = font.withSize((headerFontSize > font.pointSize) ? headerFontSize : font.pointSize)
+        let targetFont = font.withSize(font.pointSize + 4 + (-1 * CGFloat(level) * CGFloat(fontIncrease)))
         attributes[NSAttributedString.Key.font] = targetFont.bold() ?? targetFont
     }
     return attributes


### PR DESCRIPTION
The `bond()` function returns nil object as it leverage on the `fontDescriptor`, which does not work for Gotham family. 

The modification is indented to allow a preset header bold font when the `fontDescriptor` could not figure out